### PR TITLE
Fixes #4 if downstream uses the exported Backbone object

### DIFF
--- a/backbone/BackboneExport.js
+++ b/backbone/BackboneExport.js
@@ -1,0 +1,10 @@
+
+// Make way for using https://github.com/Reposoft/bmc by only exporting the data structures
+
+// No other code in this module should do the backbone require
+var backbone = require('backbone');
+
+module.exports = {
+  Model: backbone.Model,
+  Collection: backbone.Collection
+}

--- a/backbone/CollectionBImpl.js
+++ b/backbone/CollectionBImpl.js
@@ -3,7 +3,7 @@
 // The "Turn bare objects into model references" part for Backbone's annotated source is interesting
 // http://backbonejs.org/docs/backbone.html#section-90
 
-var Backbone = require('backbone');
+var Backbone = require('./BackboneExport');
 
 var Collection = module.exports = Backbone.Collection;
 

--- a/backbone/CollectionImpl.js
+++ b/backbone/CollectionImpl.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore');
 var CollectionB = require('./CollectionBImpl');
-var Backbone = require('backbone');
+var Backbone = require('./BackboneExport');
 
 var Collection = module.exports = CollectionB.extend({
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ module.exports = {
   // For migration from Backbone, resets API contract modifications from Collection
   CollectionB: require('./backbone/CollectionBImpl'),
 
+  // Required because Backbone can't out of the box handle models coming from a different require (i.e. source file) than self
+  // while such difference happens easily in an npm install where each lib has its own dependencies
+  Backbone: require('./backbone/BackboneExport'),
+
   filters: require('./backbone/FiltersBackbone')
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collection-subset",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Support Views, on a need-to-know basis",
   "main": "index.js",
   "directories": {

--- a/test/AllSpec.js
+++ b/test/AllSpec.js
@@ -1,4 +1,21 @@
+'use strict';
 
 require('../backbone/test/CollectionImplSpec');
 
 require('../pourover/test/CollectionImplSpec');
+
+var expect = require('chai').expect;
+
+var exports = require('../');
+
+describe("Module", function() {
+
+  it("Exports Backbone.Model for use in downstream models to avoid the extra wrapping issue", function() {
+    expect(exports.Backbone.Model).to.exist;
+  });
+
+  it("Exports Backbone.Collection alsongside Model so downstream logic doesn't need to import its own Backbone at all", function() {
+    expect(exports.Backbone.Collection).to.exist;
+  });
+
+});


### PR DESCRIPTION
A single Backbone `require`, also exported downstream, to satisfy `instanceof Model` without patching Backbone or overriding future _isModel.

Long term solution is to have a more npm-friendly _isModel (Backbone master, still unreleased).
